### PR TITLE
Merge message windows

### DIFF
--- a/assets/javascripts/push-service-worker.js
+++ b/assets/javascripts/push-service-worker.js
@@ -40,7 +40,12 @@ self.addEventListener('notificationclick', function(event) {
     clients.matchAll({ type: "window" })
       .then(function(clientList) {
         clientList.forEach(function(client) {
-          if (client.url === url && 'focus' in client) return client.focus();
+          if (client.url === url && 'focus' in client) {
+            return client.focus();
+          }
+          if ('navigate' in client) {
+            return client.navigate(url).then(function(client) {return client.focus();});
+          }
         });
 
         if (clients.openWindow) return clients.openWindow(url);


### PR DESCRIPTION
Naive implementation of some of the ideas listed here:

https://meta.discourse.org/t/discourse-push-notifications/46692/113?u=awole20

I haven't changed any of the message headers like the (+ 2 others) suggestion, but this is a good starting point for discussion. Separated commits for separate concerns, but I can squash later.

TLDR, I'd like to re-use windows when possible, and also not have so many discourse notififcations on my screen.