### PR TITLE
Explicit scope registration for service workers.

### DIFF
--- a/assets/javascripts/discourse/lib/push-notifications.js.es6
+++ b/assets/javascripts/discourse/lib/push-notifications.js.es6
@@ -41,7 +41,7 @@ export function isPushNotificationsSupported(mobileView) {
 export function register(user, mobileView) {
   if (!isPushNotificationsSupported(mobileView)) return;
 
-  navigator.serviceWorker.register(`${Discourse.BaseUri}/push-service-worker.js`).then(() => {
+  navigator.serviceWorker.register(`${Discourse.BaseUri}/push-service-worker.js`, {scope: './'}).then(() => {
     if (Notification.permission === 'denied' || !user) return;
 
     navigator.serviceWorker.ready.then(serviceWorkerRegistration => {


### PR DESCRIPTION
By default it should be `{scope: './'}` but this does not seem to be
true on the latest chrome on android.

https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerContainer/register

See https://meta.discourse.org/t/discourse-push-notifications/46692/123 for discussion