### PR TITLE
FEATURE: route via ember router

### DIFF
--- a/assets/javascripts/discourse/initializers/setup-push-notifications.js.es6
+++ b/assets/javascripts/discourse/initializers/setup-push-notifications.js.es6
@@ -9,11 +9,12 @@ export default {
   initialize(container) {
     withPluginApi('0.1', api => {
       const siteSettings = container.lookup('site-settings:main');
+      const router = container.lookup('router:main');
       const site = container.lookup('site:main');
 
       if (!Ember.testing && siteSettings.push_notifications_enabled) {
         const mobileView = site.mobileView;
-        registerPushNotifications(api.getCurrentUser(), mobileView);
+        registerPushNotifications(api.getCurrentUser(), mobileView, router);
       }
     });
   }

--- a/assets/javascripts/discourse/lib/push-notifications.js.es6
+++ b/assets/javascripts/discourse/lib/push-notifications.js.es6
@@ -38,7 +38,7 @@ export function isPushNotificationsSupported(mobileView) {
   return true;
 }
 
-export function register(user, mobileView) {
+export function register(user, mobileView, router) {
   if (!isPushNotificationsSupported(mobileView)) return;
 
   navigator.serviceWorker.register(`${Discourse.BaseUri}/push-service-worker.js`).then(() => {
@@ -54,6 +54,13 @@ export function register(user, mobileView) {
       }).catch(e => Ember.Logger.error(e));
     });
   }).catch(e => Ember.Logger.error(e));
+
+  navigator.serviceWorker.addEventListener('message', (event) => {
+    if('url' in event.data) {
+      const url = event.data.url;
+      router.handleURL(url);
+    }
+  });
 }
 
 export function subscribe(callback, applicationServerKey) {

--- a/assets/javascripts/push-service-worker.js
+++ b/assets/javascripts/push-service-worker.js
@@ -1,11 +1,11 @@
 /* eslint-disable */
 'use strict';
 
-function showNotification(title, body, icon, tag, url) {
+function showNotification(title, body, icon, tag, base_url, url) {
   var notificationOptions = {
     body: body,
     icon: icon,
-    data: { url: url },
+    data: { url: url, base_url: base_url },
     tag: tag
   }
 
@@ -23,7 +23,7 @@ self.addEventListener('push', function(event) {
         });
       }
 
-      return showNotification(payload.title, payload.body, payload.icon, payload.tag, payload.url);
+      return showNotification(payload.title, payload.body, payload.icon, payload.tag, payload.base_url, payload.url);
     })
   );
 });
@@ -33,6 +33,7 @@ self.addEventListener('notificationclick', function(event) {
   // See: http://crbug.com/463146
   event.notification.close();
   var url = event.notification.data.url;
+  var baseUrl = event.notification.data.base_url;
 
   // This looks to see if the current window is already open and
   // focuses if it is
@@ -40,20 +41,20 @@ self.addEventListener('notificationclick', function(event) {
     clients.matchAll({ type: "window" })
       .then(function(clientList) {
         var reusedClientWindow = clientList.some(function(client) {
-          if (client.url === url && 'focus' in client) {
+          if (client.url === baseUrl + url && 'focus' in client) {
             client.focus();
             return true;
           }
 
-          if ('navigate' in client && 'focus' in client) {
+          if ('postMessage' in client && 'focus' in client) {
             client.focus();
-            client.navigate(url);
+            client.postMessage({url: url});
             return true;
           }
           return false;
         });
 
-        if (!reusedClientWindow && clients.openWindow) return clients.openWindow(url);
+        if (!reusedClientWindow && clients.openWindow) return clients.openWindow(baseUrl + url);
       })
   );
 });

--- a/services/discourse_push_notifications/pusher.rb
+++ b/services/discourse_push_notifications/pusher.rb
@@ -18,7 +18,8 @@ module DiscoursePushNotifications
           body: payload[:excerpt],
           icon: SiteSetting.logo_small_url || SiteSetting.logo_url,
           tag: "#{Discourse.current_hostname}-#{payload[:topic_id]}",
-          url: "#{Discourse.base_url}#{payload[:post_url]}"
+          base_url: "#{Discourse.base_url}",
+          url: "#{payload[:post_url]}"
         }
 
         subject =


### PR DESCRIPTION
Hook in to ember's routing via a service worker message, rather than a navigate call.

This allows for the user to have the same navigation experience by clicking on the service worker message as they do from clicking on their in-app notification.