### PR TITLE
FEATURE: Add banner prompt for user consent

### DIFF
--- a/assets/javascripts/discourse/lib/push-notifications.js.es6
+++ b/assets/javascripts/discourse/lib/push-notifications.js.es6
@@ -7,10 +7,14 @@ export function userSubscriptionKey(user) {
   return `subscribed-${user.get('id')}`;
 }
 
-function sendSubscriptionToServer(subscription) {
+export function userDismissedPrompt(user) {
+  return `dismissed-prompt-${user.get('id')}`;
+}
+
+function sendSubscriptionToServer(subscription, sendConfirmation) {
   ajax('/push_notifications/subscribe', {
     type: 'POST',
-    data: { subscription: subscription.toJSON() }
+    data: { subscription: subscription.toJSON(), send_confirmation: sendConfirmation }
   });
 }
 
@@ -46,7 +50,7 @@ export function register(user, mobileView, router) {
   navigator.serviceWorker.ready.then(serviceWorkerRegistration => {
     serviceWorkerRegistration.pushManager.getSubscription().then(subscription => {
       if (subscription) {
-        sendSubscriptionToServer(subscription);
+        sendSubscriptionToServer(subscription, false);
         // Resync localStorage
         keyValueStore.setItem(userSubscriptionKey(user), 'subscribed');
       }
@@ -69,7 +73,7 @@ export function subscribe(callback, applicationServerKey) {
       userVisibleOnly: true,
       applicationServerKey: new Uint8Array(applicationServerKey.split("|")) // eslint-disable-line no-undef
     }).then(subscription => {
-      sendSubscriptionToServer(subscription);
+      sendSubscriptionToServer(subscription, true);
       if (callback) callback();
     }).catch(e => Ember.Logger.error(e));
   });

--- a/assets/javascripts/discourse/templates/components/push-notification-config.hbs
+++ b/assets/javascripts/discourse/templates/components/push-notification-config.hbs
@@ -3,9 +3,14 @@
     <label class="control-label">{{i18n 'discourse_push_notifications.title'}}</label>
     <div class="controls">
       <div>
-        {{#if pushNotificationSubscribed}}
+        {{#if isDeniedPermission}}
+          {{d-button icon="bell-slash-o" label="user.desktop_notifications.perm_denied_btn" disabled="true"}}
+          {{i18n "user.desktop_notifications.perm_denied_expl"}}
+        {{/if}}
+        {{#if isSubscribed}}
           {{d-button icon="bell-slash-o" label="discourse_push_notifications.disable" action="unsubscribe"}}
-        {{else}}
+        {{/if}}
+        {{#if isAvailable}}
           {{d-button icon="bell-o" label="discourse_push_notifications.enable" action="subscribe"}}
         {{/if}}
       </div>

--- a/assets/javascripts/discourse/templates/components/push-notification-consent.hbs
+++ b/assets/javascripts/discourse/templates/components/push-notification-consent.hbs
@@ -1,0 +1,14 @@
+{{#if showPushNotificationPrompt}}
+  {{#unless bannerDismissed}}
+    {{#unless pushNotificationSubscribed}}
+      <div class="wrap">
+        <div class="row">
+          <div class="consent_banner alert alert-info">
+            <div class="close" {{action "dismiss"}}><i class="fa fa-times d-icon d-icon-times"></i></div>
+            {{i18n 'discourse_push_notifications.consent_prompt'}} <a {{action "subscribe"}}>{{i18n 'discourse_push_notifications.consent_enable'}}</a>.
+          </div>
+        </div>
+      </div>
+    {{/unless}}
+  {{/unless}}
+{{/if}}

--- a/assets/javascripts/discourse/templates/connectors/below-site-header/push-notification-prompt.hbs
+++ b/assets/javascripts/discourse/templates/connectors/below-site-header/push-notification-prompt.hbs
@@ -1,0 +1,1 @@
+{{push-notification-consent}}

--- a/assets/stylesheets/push-notifications.scss
+++ b/assets/stylesheets/push-notifications.scss
@@ -1,0 +1,4 @@
+.push-notification-prompt {
+  position: relative;
+  top: 82px;
+}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6,3 +6,5 @@ en:
       enable: "Enable Push Notifications"
       enable_note: "You have to change this setting on every browser you use and this will disable Desktop Notifications."
       disable_note: "You have to change this setting on every browser you use."
+      consent_prompt: "This site needs your permission to"
+      consent_enable: "enable notifications"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -1,6 +1,7 @@
 en:
   site_settings:
     push_notifications_enabled: Enable push notifications?
+    push_notifications_prompt: Display user consent prompt.
   discourse_push_notifications:
     popup:
       mentioned: '%{username} mentioned you in "%{topic}" - %{site_title}'
@@ -10,3 +11,5 @@ en:
       posted: '%{username} posted in "%{topic}" - %{site_title}'
       private_message: '%{username} sent you a private message in "%{topic}" - %{site_title}'
       linked: '%{username} linked to your post from "%{topic}" - %{site_title}'
+      confirm_title: 'Notifications enabled - %{site_title}'
+      confirm_body: 'Success! Notifications have been enabled.'

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -2,6 +2,9 @@ plugins:
   push_notifications_enabled:
     default: false
     client: true
+  push_notifications_prompt:
+    default: false
+    client: true
   vapid_public_key_bytes:
     default: ''
     client: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -10,6 +10,7 @@ gem 'webpush', '0.3.2'
 enabled_site_setting :push_notifications_enabled
 
 register_service_worker "javascripts/push-service-worker.js"
+register_asset "stylesheets/push-notifications.scss"
 
 after_initialize do
   module ::DiscoursePushNotifications
@@ -52,7 +53,7 @@ after_initialize do
     skip_before_action :preload_json
 
     def subscribe
-      DiscoursePushNotifications::Pusher.subscribe(current_user, push_params)
+      DiscoursePushNotifications::Pusher.subscribe(current_user, push_params, params[:send_confirmation])
       render json: success_json
     end
 


### PR DESCRIPTION
Add an option to prompt a banner for a user's consent on the main screen (off by default).

* Do not show the banner if a user has already subscribed, or has dismissed the banner.
* Do not show the banner if a user is logged out.
* Add a universal confirmation notification once a user subscribes, similar to slack/discord. This also can help confirm that the notifications are in good working order.

Most of the work here was inspired by the way slack handles notifications, by having a predominant prompt without nagging about it.