### PR TITLE
FIX: custom fields not merging correctly

### DIFF
--- a/services/discourse_push_notifications/pusher.rb
+++ b/services/discourse_push_notifications/pusher.rb
@@ -56,6 +56,14 @@ module DiscoursePushNotifications
 
     def self.subscriptions(user)
       user.custom_fields[DiscoursePushNotifications::PLUGIN_NAME] ||= {}
+      # this might be an array due to merging, so resovle the merge.
+      if user.custom_fields[DiscoursePushNotifications::PLUGIN_NAME].kind_of?(Array)
+        merged_subscriptions = {}
+        user.custom_fields[DiscoursePushNotifications::PLUGIN_NAME].each do |subscription|
+          merged_subscriptions = merged_subscriptions.merge(subscription[SUBSCRIPTION_KEY])
+        end
+        user.custom_fields[DiscoursePushNotifications::PLUGIN_NAME] = merged_subscriptions
+      end
       user.custom_fields[DiscoursePushNotifications::PLUGIN_NAME][SUBSCRIPTION_KEY] ||= {}
       user.custom_fields[DiscoursePushNotifications::PLUGIN_NAME][SUBSCRIPTION_KEY]
     end


### PR DESCRIPTION
Sometimes a user's subscriptions will merge into an array (observed
when subscribing/unsubscribing very rapidly.) This throws a
`TypeError: no implicit conversion of String into Integer`.

This fix handles a merge into an array and correctly splits out the
custom field back into a hash as expected.

Hopefully this should alleviate the issue found from testing #14 