### PR TITLE
FIX: Register service workers on subscribe.

### DIFF
--- a/assets/javascripts/discourse/lib/push-notifications.js.es6
+++ b/assets/javascripts/discourse/lib/push-notifications.js.es6
@@ -61,16 +61,18 @@ export function register(user, mobileView, router) {
 }
 
 export function subscribe(callback, applicationServerKey) {
-  if (!isPushNotificationsSupported()) return;
+  navigator.serviceWorker.register(`${Discourse.BaseUri}/service-worker.js`).then((reg) => {
+    if (!isPushNotificationsSupported()) return;
 
-  navigator.serviceWorker.ready.then(serviceWorkerRegistration => {
-    serviceWorkerRegistration.pushManager.subscribe({
-      userVisibleOnly: true,
-      applicationServerKey: new Uint8Array(applicationServerKey.split("|")) // eslint-disable-line no-undef
-    }).then(subscription => {
-      sendSubscriptionToServer(subscription);
-      if (callback) callback();
-    }).catch(e => Ember.Logger.error(e));
+    navigator.serviceWorker.ready.then(serviceWorkerRegistration => {
+      serviceWorkerRegistration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: new Uint8Array(applicationServerKey.split("|")) // eslint-disable-line no-undef
+      }).then(subscription => {
+        sendSubscriptionToServer(subscription);
+        if (callback) callback();
+      }).catch(e => Ember.Logger.error(e));
+    });
   });
 }
 


### PR DESCRIPTION
Current bug:
Ensure disabled "enable push notifications?" and no service workers registered.
User navigates to Discourse instance - no push service worker active.
Admin enables plugin "enable push notifications?" setting.
User navigates without refreshing to profile page, note unresponsive
register button.

To resolve, register the service worker, and ensure it is
"active" via skipWaiting on a register request.

*note this currently conflicts with #14 but it's pretty trivial to resolve. Whichever one is pulled first, I'll be able to rebase the other PR to be clean.